### PR TITLE
pasteBoard 틀 구현 + 폴더폼 토스트 내용 분기처리

### DIFF
--- a/Linkllet-iOS/Linkllet-iOS/Presentation/FolderForm/View/FolderFormViewController.swift
+++ b/Linkllet-iOS/Linkllet-iOS/Presentation/FolderForm/View/FolderFormViewController.swift
@@ -280,7 +280,12 @@ extension FolderFormViewController {
         case .saved:
             inputTitleView.layer.borderWidth = 0
             NotificationCenter.default.post(name: .didSaveFolder, object: nil, userInfo: ["folderName": viewModel.titleSubject.value])
-            UIViewController.showToast("폴더가 생성되었습니다")
+            switch viewModel.formType.value {
+            case .create:
+                UIViewController.showToast("폴더가 생성되었습니다")
+            case .edit:
+                UIViewController.showToast("폴더가 수정되었습니다")
+            }
             dismiss(animated: true)
         case .emptyError:
             inputTitleView.layer.borderWidth = 2

--- a/Linkllet-iOS/Linkllet-iOS/Presentation/LinkForm/LinkFormViewController.swift
+++ b/Linkllet-iOS/Linkllet-iOS/Presentation/LinkForm/LinkFormViewController.swift
@@ -145,6 +145,7 @@ extension LinkFormViewController: UICollectionViewDataSource {
             cell.updateUI(with: item)
 
             cell.textField.keyboardType = .URL
+            cell.textField.text = viewModel.pastedUrl?.absoluteString
             cell.textFieldDidChangePublisher
                 .sink { [weak self] urlString in
                     self?.viewModel.state.articleURLString.send(urlString)
@@ -324,12 +325,14 @@ final class LinkFormViewModel {
     let state = State()
     let action = Action()
     let initialFolder: Folder?
+    let pastedUrl: URL?
 
     private let network: NetworkProvider = NetworkService()
     private var cancellables = Set<AnyCancellable>()
 
-    init(initialFolder: Folder? = nil) {
+    init(initialFolder: Folder? = nil, pastedUrl: URL? = nil) {
         self.initialFolder = initialFolder
+        self.pastedUrl = pastedUrl
         setPublisher()
     }
 

--- a/Linkllet-iOS/Linkllet-iOS/Presentation/Wallet/View/WalletViewController.swift
+++ b/Linkllet-iOS/Linkllet-iOS/Presentation/Wallet/View/WalletViewController.swift
@@ -113,6 +113,20 @@ final class WalletViewController: UIViewController {
         setDelegate()
         setBindings()
         setErrorView()
+        
+        if let storedString = UIPasteboard.general.string {
+            guard let urlString = URL(string: storedString) else { return }
+            let alert = UIAlertController(title: nil, message: "복사한 링크 저장하기", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "저장", style: .default) { _ in
+                if let vc = LinkFormViewController.create(viewModel: LinkFormViewModel(pastedUrl: urlString)) {
+                    vc.modalPresentationStyle = .overFullScreen
+                    self.present(vc, animated: true)
+                }
+            }
+            alert.addAction(okAction)
+            alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+            present(alert, animated: true, completion: nil)
+        }
     }
 }
 


### PR DESCRIPTION
- pasteBoard에서 저장된 string이 url 형식일 경우 알럿띄우기 + 링크폼 이동 시 textField 초기값으로 저장된 링크 넣기

https://github.com/Nexters/Linkllet-iOS/assets/58043306/f3d9accb-4c0f-492e-a93d-0bbf73fdb5d5

- 폴더폼 토스트 내용 분기처리 (폴더 생성, 폴더 수정 시)

